### PR TITLE
prevent what-input js error and bring inline with current ZURB Templa…

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -72,7 +72,7 @@ function javascript() {
   // get all the foundation javascript libraries && anything custom (see config.yml)
   return gulp.src(PATHS.javascript)
     .pipe($.sourcemaps.init())
-    .pipe($.babel())
+    .pipe($.babel({ignore: ['what-input.js']}))
     .pipe($.concat('app.js'))
     // with the --production flag, the file is minified
     .pipe($.if(PRODUCTION, $.uglify()


### PR DESCRIPTION
I ran into an issue with what-input and the way that it is implemented throwing a js error and preventing foundation from instantiating. If you check the current ZURB Template release, you will see that this patch brings it up to date with what is in that repo.